### PR TITLE
Fix non-matching action during index-zip upload

### DIFF
--- a/akamai/netstorage/netstorage.py
+++ b/akamai/netstorage/netstorage.py
@@ -118,7 +118,7 @@ class Netstorage:
         elif kwargs['method'] == 'PUT': # Use only upload
             if 'stream' in kwargs.keys():
                 response = self.http_client.put(request_url, headers=headers, data=kwargs['stream'])
-            elif kwargs['action'] == 'upload':
+            elif kwargs['action'].startswith('upload'):
                 mmapped_data = self._upload_data_to_request(kwargs['source'])
                 response = self.http_client.put(request_url, headers=headers, data=mmapped_data)
                 mmapped_data.close()


### PR DESCRIPTION
```
        action = 'upload'        
        if index_zip: # Support only For File Store, not Object Store.
            action = action + '&index-zip=1'
```

Does not mesh with 

```
elif kwargs['action'] == 'upload':
```

Causing `response` to be `None` and no upload to process.