### PR TITLE
Update cms_netstorage

### DIFF
--- a/cms_netstorage.py
+++ b/cms_netstorage.py
@@ -112,6 +112,8 @@ if __name__ == '__main__':
                 ok, res = ns.symlink(args[0], args[1])
             elif options.action == 'upload':
                 ok, res = ns.upload(args[0], args[1])
+            elif options.action == 'rename':
+                ok, res = ns.rename(args[0], args[1])
             else:
                 print("Invalid action.\nUse option -h or --help")
                 exit()


### PR DESCRIPTION
'rename' feature was not fully implemented in that code.
Using the rename feature was generating that error message : Invalid action
This is fixed now with that updated version, rename is fully functional here