### PR TITLE
added a third parameter to allow index-zip for the upload action

### DIFF
--- a/cms_netstorage.py
+++ b/cms_netstorage.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
             elif options.action == 'symlink':
                 ok, res = ns.symlink(args[0], args[1])
             elif options.action == 'upload':
-                ok, res = ns.upload(args[0], args[1])
+                ok, res = ns.upload(args[0], args[1], args[2])
             elif options.action == 'rename':
                 ok, res = ns.rename(args[0], args[1])
             else:


### PR DESCRIPTION
Can you please allow to pass the index_zip parameter in the upload action in cms_netstorage.py?
We want to use the Serve from Zip feature, we must first index the archive file to create a hash table of its contents. To achieve this, we must pass this parameter as the third parameter in the upload action in cms_netstorage.py