### PR TITLE
Updated the script to add support for Folder UploadsAdd folder upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ target/
 .DS_Store
 test/secret.py
 spike/
+
+
+# PyBuilder
+.vscode/

--- a/cms_netstorage.py
+++ b/cms_netstorage.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#adding folderUpload support
 
 import ast
 import optparse, sys


### PR DESCRIPTION
The script has been updated to support folder uploads. The folder can contain subfolders and the whole folder structure is preserved while it uploads to NetStorage.

updated the action list

upload: to upload file.txt or a folder to /123456 directory
upload file.txt /123456/ or
upload uploaddir /123456/uploaddir